### PR TITLE
install cloud-init datasource for RHEL 7.9

### DIFF
--- a/scripts/common/finish_cloud_init.sh
+++ b/scripts/common/finish_cloud_init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eux
 
-# ensure vmware datasoruce
-echo 'datasource_list: [ "VMware", "OVF" ]' > /etc/cloud/cloud.cfg.d/99-ovf-data.cfg
+# ensure vmware datasource
+echo 'datasource_list: [ "VMware", "OVF", "VMwareGuestInfo" ]' > /etc/cloud/cloud.cfg.d/99-ovf-data.cfg
 
 echo "Cloud-Init version"
 cloud-init --version

--- a/scripts/el/el7_install_cloud_init-vmware-ds.sh
+++ b/scripts/el/el7_install_cloud_init-vmware-ds.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -eux
+
+export REPO_SLUG="https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo"
+export GIT_REF="v1.4.1"
+
+DATASOURCE_INSTALL_URL="${REPO_SLUG}/${GIT_REF}/install.sh"
+
+curl -o- ${DATASOURCE_INSTALL_URL} | bash -o errexit -o pipefail

--- a/scripts/el/install_cloud_tools.sh
+++ b/scripts/el/install_cloud_tools.sh
@@ -11,5 +11,6 @@ if [ "$major_version" -ge 8 ]; then
     dnf -y install open-vm-tools cloud-init cloud-utils-growpart
 else
     # with el7 we install cloud-init from source
-    yum install -y open-vm-tools cloud-utils-growpart dracut-modules-growroot
+    yum install -y open-vm-tools cloud-init cloud-utils-growpart dracut-modules-growroot https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    yum install -y python2-pip
 fi

--- a/vsphere.pkr.hcl
+++ b/vsphere.pkr.hcl
@@ -398,10 +398,9 @@ locals {
     ],
     "RHEL-7" = [
       "${path.root}/scripts/el/rhn_add_subscription.sh",
-      "${path.root}/scripts/el/el7_ensure_python.sh",
       "${path.root}/scripts/el/install_open_vm_tools.sh",
-      "${path.root}/scripts/common/cloudinit_from_source.sh",
       "${path.root}/scripts/el/install_cloud_tools.sh",
+      "${path.root}/scripts/el/el7_install_cloud_init-vmware-ds.sh",
       "${path.root}/scripts/el/cleanup_yum.sh",
       "${path.root}/scripts/el/rhn_remove_subscription.sh"
     ],


### PR DESCRIPTION
- Installs cloud-init datasource for vmware that is compatible with the `cloud-init 19.4` rpm shipped from RedHat for RHEL 7.9 https://github.com/vmware-archive/cloud-init-vmware-guestinfo/blob/master/DataSourceVMwareGuestInfo.py#L71
- Remove ensuring python3 for RHEL 7.9 . Many pip packages available in air-gapped bundles for RHEL 7.9 are python2 compatible. The `cloud-init 19.4` is also tested and compatible with `python 2.7`

Tested this PR by creating VM `cluster-api/base-rhel-7.9` and creating cluster using the template.
```
NAME                                    CLUSTER           NODENAME                                PROVIDERID                                       PHASE     AGE     VERSION
shalin-rhel-7.9-control-plane-2j9xp     shalin-rhel-7.9   shalin-rhel-7.9-control-plane-2j9xp     vsphere://4216d022-8b29-a09e-4dc5-96ef73257ff2   Running   8m21s   v1.26.3
shalin-rhel-7.9-control-plane-6ghhr     shalin-rhel-7.9   shalin-rhel-7.9-control-plane-6ghhr     vsphere://421608b5-400e-c5ef-91ce-152a7c37dcb0   Running   13m     v1.26.3
shalin-rhel-7.9-control-plane-jgzxx     shalin-rhel-7.9   shalin-rhel-7.9-control-plane-jgzxx     vsphere://421637cc-ab36-4de9-4064-a7dd13097ac6   Running   17m     v1.26.3
shalin-rhel-7.9-md-0-546dd88989-2dxgh   shalin-rhel-7.9   shalin-rhel-7.9-md-0-546dd88989-2dxgh   vsphere://4216e4d3-c2d4-f18d-5637-cc5cfcb4eb10   Running   17m     v1.26.3
shalin-rhel-7.9-md-0-546dd88989-nkd9k   shalin-rhel-7.9   shalin-rhel-7.9-md-0-546dd88989-nkd9k   vsphere://4216190c-8109-c638-b355-fa10f1dbe612   Running   17m     v1.26.3
shalin-rhel-7.9-md-0-546dd88989-nmjxn   shalin-rhel-7.9   shalin-rhel-7.9-md-0-546dd88989-nmjxn   vsphere://42164a13-ff1b-6486-ee4e-c434df65c67c   Running   17m     v1.26.3
shalin-rhel-7.9-md-0-546dd88989-pdx9b   shalin-rhel-7.9   shalin-rhel-7.9-md-0-546dd88989-pdx9b   vsphere://42160609-0a24-6b59-5972-6537521baaa3   Running   17m     v1.26.3

```