### PR TITLE
fix: Do not create a directory where the OS expects a udev rules file

### DIFF
--- a/scripts/el/cleanup_dnf.sh
+++ b/scripts/el/cleanup_dnf.sh
@@ -30,7 +30,6 @@ dnf -y clean all --enablerepo=\*
 
 # Clean up network interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules;
-mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
 rm -rf /dev/.udev/;
 

--- a/scripts/el/cleanup_yum.sh
+++ b/scripts/el/cleanup_yum.sh
@@ -30,7 +30,6 @@ yum -y clean all  --enablerepo=\*;
 
 # Clean up network interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules;
-mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
 rm -rf /dev/.udev/;
 


### PR DESCRIPTION
When this directory exists, cloud-init-local fails with an error, because it cannot create a file when a directory with the same name already exists.