### PR TITLE
feat: import flatcar production OVA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,8 @@ rhel-release-84: rhel-test-84 release/d2iq-base-RHEL-84$(NAME_POSTFIX)
 rhel-release-86: rhel-test-86 release/d2iq-base-RHEL-86$(NAME_POSTFIX)
 rhel-release: rhel-release-79 rhel-release-84 rhel-release-86
 
+flatcar: $(GOVC)
+	./scripts/flatcar/import.sh
+
 test-all: ubuntu-test rocky-test centos-test rhel-test
-release: ubuntu-release rocky-release centos-release rhel-release
+release: ubuntu-release rocky-release centos-release rhel-release flatcar

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Following variables must be set according to structure of the vSphere setup:
 - `PKR_VAR_vsphere_datacenter`: name of the vsphere datacenter to be used
 - `PKR_VAR_vsphere_cluster`: name of the vsphere cluster to be used
 - `PKR_VAR_vsphere_datastore`: the datastore templates and vms are placed on
-- `PKR_VAR_vsphere_network`: a vSphere network which can be reached from the machine running the build ( SSH ports needed )
+- `PKR_VAR_vsphere_network`: a vSphere network which can be reached from the machine 
+running the build ( SSH ports needed )
+- `PKR_VAR_vsphere_resource_pool`: a vSphere resource pool to be used
+- `PKR_VAR_vsphere_folder`: the vSphere folder to place the virtual machine
 
 ### RHEL
 For Red Hat Enterprise Linux builds you need to set
@@ -39,6 +42,7 @@ There are distribution based make targets for building images
 - `make rocky` - Ubuntu 8 and 9
 - `make centos` - Centos 7.9
 - `make rhel` - RHEL 7.9, 8.4, and 8.6
+- `make flatcar` - Flatcar LTS
 
 Templates and VMs are created by default in the folder `build-d2iq-base-templates` This can be changed by injecting the environment variable `VSPHERE_FOLDER`
 

--- a/mkinclude/govc.mk
+++ b/mkinclude/govc.mk
@@ -5,8 +5,8 @@ uname_m = $(shell uname -m)
 
 GOVC_URL ?= $(VSPHERE_USER):$(VSPHERE_PASSWORD)@$(VSPHERE_SERVER)
 
-# Path to Terraform binary.
-GOVC ?= tmp/govc.bin
+# Path to govc binary.
+export GOVC ?= tmp/govc.bin
 
 tmp/govc_$(GOVC_VERSION)_$(OS)_$(ARCH).tar.gz:
 	wget -O $@ -nv https://github.com/vmware/govmomi/releases/download/v$(GOVC_VERSION)/govc_$(OS)_$(uname_m).tar.gz

--- a/scripts/flatcar/import.sh
+++ b/scripts/flatcar/import.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+
+DATACENTER=${DATACENTER:-$PKR_VAR_vsphere_datacenter}
+DATASTORE=${DATASTORE:-$PKR_VAR_vsphere_datastore}
+VM_FOLDER=${VM_FOLDER:-$PKR_VAR_vsphere_folder}
+RESOURCE_POOL=${RESOURCE_POOL:-$PKR_VAR_vsphere_resource_pool}
+
+FLATCAR_LTS_VERSION=${FLATCAR_LTS_VERSION:-"lts"}
+
+VM_NAME=d2iq-base-Flatcar-${FLATCAR_LTS_VERSION}
+
+wget -O "${VM_NAME}.ova" -nv https://lts.release.flatcar-linux.net/amd64-usr/${FLATCAR_LTS_VERSION}/flatcar_production_vmware_ova.ova
+
+${GOVC} import.ova -dc="${DATACENTER}" -ds="${DATASTORE}" -folder="${VM_FOLDER}" -pool="${RESOURCE_POOL}"  -name="${VM_NAME}" "${VM_NAME}.ova"
+
+${GOVC} snapshot.create -vm "${VM_NAME}" snapshot_1
+${GOVC} vm.markastemplate "${VM_NAME}"


### PR DESCRIPTION
unlike RHEL and Ubuntu, flatcar publishes production OVA that can be used directly as base OS. https://lts.release.flatcar-linux.net/amd64-usr/3033.3.16/
This PR takes different approach for flatcar where it imports flatcar OVA instead of building it from ISO.

`make flatcar` target will directly download and import flatcar OVA to vCenter. 
@fatz Please let me know how to get these base templates to the release folder. 