### PR TITLE
initial flatcar iso

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu", "rocky", "centos", "rhel"]
+        os: ["ubuntu", "rocky", "centos", "rhel", "flatcar"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,12 @@ rhel-release-84: rhel-test-84 release/d2iq-base-RHEL-84$(NAME_POSTFIX)
 rhel-release-86: rhel-test-86 release/d2iq-base-RHEL-86$(NAME_POSTFIX)
 rhel-release: rhel-release-79 rhel-release-84 rhel-release-86
 
+flatcar: manifests/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).json
+flatcar-test-3033: manifests/tests/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).json.clean
+flatcar-test-3033-clean: flatcar-test-3033 manifests/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).json.clean
+flatcar-test: flatcar-test-3033-clean
+flatcar-release-3033: flatcar-test-3033 release/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX)
+flatcar-release: flatcar-release-3033
+
 test-all: ubuntu-test rocky-test centos-test rhel-test
 release: ubuntu-release rocky-release centos-release rhel-release

--- a/bootfiles/flatcar/bootfile.sh.tmpl
+++ b/bootfiles/flatcar/bootfile.sh.tmpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat <<EOF >/tmp/bootcloudinit.yaml
+#cloud-config
+variant: flatcar
+version: 1.0.0
+kernel_arguments:
+  should_not_exist:
+    - flatcar.autologin
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - "${public_key}"
+EOF
+
+flatcar-install -d /dev/sda -o vmware_raw -c /tmp/bootcloudinit.yaml
+
+reboot

--- a/images/base-Flatcar-3033.3.16.pkrvar.hcl
+++ b/images/base-Flatcar-3033.3.16.pkrvar.hcl
@@ -1,0 +1,4 @@
+distribution="Flatcar"
+distribution_version="3033.3.16"
+iso_url="https://lts.release.flatcar-linux.net/amd64-usr/3033.3.16/flatcar_production_iso_image.iso"
+iso_checksum="fe9dc93ceaf06c10c94fc3a25a067b175ad280062d0dafdda1a75a186dd011ba27f598aa11c201e1ba9ae1c883aacd30559897fd26003a187a9da90830e19fd2"

--- a/scripts/common/clean_authorized_keys.sh
+++ b/scripts/common/clean_authorized_keys.sh
@@ -1,8 +1,4 @@
 #!/bin/bash -eux
-
-echo "Cloud-Init version"
-cloud-init --version
-
 # check for BASE_IMAGE_SSH_USER
 test -n "${BASE_IMAGE_SSH_USER}"
 

--- a/scripts/common/finish_cloud_init.sh
+++ b/scripts/common/finish_cloud_init.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -eux
 
+# exit if flatcar
+if [[ $(grep -c Flatcar /etc/os-release) -gt 0 ]]; then
+  # FIXME: this is a workaround for flat car support. We need to find a better way to do this.
+  exit 0
+fi
+
 # ensure vmware datasource
 echo 'datasource_list: [ "VMware", "OVF", "VMwareGuestInfo" ]' > /etc/cloud/cloud.cfg.d/99-ovf-data.cfg
 

--- a/vsphere.pkr.hcl
+++ b/vsphere.pkr.hcl
@@ -208,6 +208,7 @@ locals {
     "CentOS"          = "${path.root}/bootfiles/centos/centos7.ks"
     "Ubuntu"          = "${path.root}/bootfiles/ubuntu/autoinstall.yaml"
     "Ubuntu-18.04"    = "${path.root}/bootfiles/ubuntu/preseed.cfg"
+    "Flatcar"         = "${path.root}/bootfiles/flatcar/bootfile.sh.tmpl"
   }
 
   el_old_bootcommand = [
@@ -257,6 +258,13 @@ locals {
     "<enter>"
   ]
 
+  flatcar_bootcommand = [
+    "<wait><wait><wait>",
+    "sudo mkdir /bootfiles<enter>",
+    "sudo mount -o loop /dev/sr1 /bootfiles<enter>",
+    "sudo bash /bootfiles/bootfile.sh<enter>",
+  ]
+
   # lookup by <distro_name>-<distro_version> fallback to <distro_name>
   distro_boot_command_lookup = {
     "RHEL-7"       = local.el_old_bootcommand
@@ -266,6 +274,7 @@ locals {
     "Ubuntu-18.04" = local.ubuntu_bionic_bootcommand
     "Ubuntu-20.04" = local.ubuntu_bootcommand
     "Ubuntu-22.04" = local.ubuntu_jammy_bootcommand
+    "Flatcar"      = local.flatcar_bootcommand
   }
 
   default_firmware = "bios"
@@ -282,7 +291,8 @@ locals {
 
   # lookup by <distro_name>-<distro_version> fallback to <distro_version> fallback to ""
   distro_cd_label_lookup = {
-    "Ubuntu" = "cidata"
+    "Ubuntu" = "cidata",
+    "Flatcar" = "cidata"
   }
 
   default_vsphere_guest_os_type = "otherlinux64guest"
@@ -292,6 +302,7 @@ locals {
     "CentOS"     = "centos64Guest",
     "RHEL"       = "rhel7_64Guest"
     "RockyLinux" = "centos64Guest"
+    "Flatcar"    = "otherlinux64Guest"
   }
 
   # lookup by <distro_name>-<distro_version> fallback to <distro_name>
@@ -300,6 +311,7 @@ locals {
     "CentOS"     = "centos",
     "RHEL"       = "eluser"
     "RockyLinux" = "rockstar"
+    "Flatcar"    = "core"
   }
 
   boot_command_distro = lookup(local.distro_boot_command_lookup, "${var.distribution}", [""])
@@ -341,6 +353,7 @@ source "vsphere-iso" "baseimage" {
 
   cd_content = {
     "/bootfile.cfg" = local.bootfile,
+    "/bootfile.sh" = local.bootfile,
     # make it cloud-config compatible
     "/user-data"       = local.bootfile,
     "/meta-data"       = "",
@@ -417,6 +430,7 @@ locals {
       "${path.root}/scripts/el/install_open_vm_tools.sh",
       "${path.root}/scripts/el/cleanup_dnf.sh"
     ],
+    "Flatcar" = []
   }
 
   common_pre_distro = []


### PR DESCRIPTION
This is a different solution to #7

Still it does not fully work as the test fails and cloud-init does not being picked up.

As these base templates are ultimately meant for CAPI the question would be if capi/capv are using ignition instead?

In that case we would need to replicate the support in our test