### PR TITLE
fix: generate ignition config for flatcar

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ To be able to install RHEL you would need to provide an ISO to the vSphere clust
 
 `PKR_VAR_iso_path_entry="[your-data-store-name] path/to/rhel-server-7.9-x86_64-dvd.iso"` tells packer where to get the ISO from
 
+### Flatcar
+Flatar builds requries ignition templates for boot
+- run `hack/flatcar/build_ignition.sh` to generate ignition configuration at `/tmp/ignition.json`
+- copy the contents of `/tmp/ignition.json` to `bootfiles/flatcar/bootfile.sh.tmpl`
+
 ## Build
 
 There are distribution based make targets for building images
@@ -43,6 +48,7 @@ There are distribution based make targets for building images
 - `make rocky` - Ubuntu 8 and 9
 - `make centos` - Centos 7.9
 - `make rhel` - RHEL 7.9, 8.4, and 8.6
+- `make flatcar` - Flatcar LTS
 
 Templates and VMs are created by default in the folder `build-d2iq-base-templates` This can be changed by injecting the environment variable `VSPHERE_FOLDER`
 

--- a/bootfiles/flatcar/bootfile.sh.tmpl
+++ b/bootfiles/flatcar/bootfile.sh.tmpl
@@ -1,19 +1,46 @@
 #!/bin/bash
 
-cat <<EOF >/tmp/bootcloudinit.yaml
-#cloud-config
-variant: flatcar
-version: 1.0.0
-kernel_arguments:
-  should_not_exist:
-    - flatcar.autologin
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - "${public_key}"
+cat <<EOF >/tmp/ignition.json
+{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.3.0"
+  },
+  "networkd": {},
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "${public_key}"
+        ]
+      }
+    ]
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enable": true,
+        "name": "docker.service"
+      },
+      {
+        "mask": true,
+        "name": "update-engine.service"
+      },
+      {
+        "mask": true,
+        "name": "locksmithd.service"
+      }
+    ]
+  }
+}
 EOF
 
-flatcar-install -d /dev/sda -o vmware_raw -c /tmp/bootcloudinit.yaml
+flatcar-install -d /dev/sda -o vmware_raw -C lts -i /tmp/ignition.json
 
 reboot

--- a/hack/flatcar/build_ignition.sh
+++ b/hack/flatcar/build_ignition.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+cat <<EOF >/tmp/clc.yaml
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - "\${public_key}"
+systemd:
+  units:
+  - name: docker.service
+    enable: true
+  # Mask update-engine and locksmithd to disable automatic updates during image creation.
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true
+EOF
+
+CT_VER=v0.9.3
+
+# Specify Architecture
+# ARCH=aarch64 # ARM's 64-bit architecture
+ARCH=x86_64
+
+# Specify OS
+# OS=apple-darwin # MacOS
+# OS=pc-windows-gnu.exe # Windows
+OS=unknown-linux-gnu # Linux
+if [[ `uname -s` == "Darwin" ]]; then
+OS=apple-darwin
+fi
+
+# Specify download URL
+DOWNLOAD_URL=https://github.com/flatcar/container-linux-config-transpiler/releases/download
+CT_BIN="/tmp/ct-${CT_VER}-${ARCH}-${OS}"
+
+# Remove previous downloads
+rm -f "${CT_BIN}" "${CT_BIN}.asc" /tmp/coreos-app-signing-pubkey.gpg
+
+# Download Config Transpiler binary
+curl -L ${DOWNLOAD_URL}/${CT_VER}/ct-${CT_VER}-${ARCH}-${OS} -o "${CT_BIN}"
+chmod u+x ${CT_BIN}
+
+${CT_BIN} < /tmp/clc.yaml | jq '.' | tee /tmp/ignition.json


### PR DESCRIPTION
This PR is stacked on https://github.com/mesosphere/vsphere-base-template/pull/8
Generates ignition templates and boots flatcar with ignition template.
Tested using my account and generated `d2iq-base-Flatcar-3033.3.16-manual-build-shalpatel` successfully. 