### PR TITLE
feat: build base template for RHEL 8.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,15 +82,19 @@ rhel-test-84: manifests/tests/d2iq-base-RHEL-84$(NAME_POSTFIX).json.clean
 rhel-test-84-clean: rhel-test-84 manifests/d2iq-base-RHEL-84$(NAME_POSTFIX).json.clean
 rhel-test-86: manifests/tests/d2iq-base-RHEL-86$(NAME_POSTFIX).json.clean
 rhel-test-86-clean: rhel-test-86 manifests/d2iq-base-RHEL-86$(NAME_POSTFIX).json.clean
-rhel-test: rhel-test-79-clean rhel-test-84-clean rhel-test-86-clean
+rhel-test-88: manifests/tests/d2iq-base-RHEL-88$(NAME_POSTFIX).json.clean
+rhel-test-88-clean: rhel-test-88 manifests/d2iq-base-RHEL-88$(NAME_POSTFIX).json.clean
+rhel-test: rhel-test-79-clean rhel-test-84-clean rhel-test-86-clean rhel-test-88-clean
 rhel-release-79: rhel-test-79 release/d2iq-base-RHEL-79$(NAME_POSTFIX)
 rhel-release-84: rhel-test-84 release/d2iq-base-RHEL-84$(NAME_POSTFIX)
 rhel-release-86: rhel-test-86 release/d2iq-base-RHEL-86$(NAME_POSTFIX)
-rhel-release: rhel-release-79 rhel-release-84 rhel-release-86
+rhel-release-88: rhel-test-88 release/d2iq-base-RHEL-88$(NAME_POSTFIX)
+rhel-release: rhel-release-79 rhel-release-84 rhel-release-86 rhel-release-88
 rhel-ovf-79: manifests/ovf/d2iq-base-RHEL-79$(NAME_POSTFIX).ovf
 rhel-ovf-84: manifests/ovf/d2iq-base-RHEL-84$(NAME_POSTFIX).ovf
 rhel-ovf-86: manifests/ovf/d2iq-base-RHEL-86$(NAME_POSTFIX).ovf
-rhel-ovf: rhel-ovf-79 rhel-ovf-84 rhel-ovf-86
+rhel-ovf-88: manifests/ovf/d2iq-base-RHEL-88$(NAME_POSTFIX).ovf
+rhel-ovf: rhel-ovf-79 rhel-ovf-84 rhel-ovf-86 rhel-ovf-88
 
 flatcar: manifests/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).json
 flatcar-test-3033: manifests/tests/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).json
@@ -100,6 +104,7 @@ flatcar-release-3033: flatcar-test-3033 release/d2iq-base-Flatcar-3033.3.16$(NAM
 flatcar-release: flatcar-release-3033
 flatcar-ovf-3033: manifests/ovf/d2iq-base-Flatcar-3033.3.16$(NAME_POSTFIX).ovf
 flatcar-ovf: flatcar-ovf-3033
+
 
 test-all: ubuntu-test rocky-test centos-test rhel-test
 release: ubuntu-release rocky-release centos-release rhel-release

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ There are distribution based make targets for building images
 - `make ubuntu` - Ubuntu 20.04 and 22.04
 - `make rocky` - Ubuntu 8 and 9
 - `make centos` - Centos 7.9
-- `make rhel` - RHEL 7.9, 8.4, and 8.6
 - `make flatcar` - Flatcar LTS
+- `make rhel` - RHEL 7.9, 8.4, 8.6 and 8.8
 
 Templates and VMs are created by default in the folder `build-d2iq-base-templates` This can be changed by injecting the environment variable `VSPHERE_FOLDER`
 

--- a/images/base-RHEL-88.pkrvar.hcl
+++ b/images/base-RHEL-88.pkrvar.hcl
@@ -1,0 +1,7 @@
+distribution="RHEL"
+distribution_version="8"
+# very specific for D2iQ internal setup. Please use PKR_VAR_iso_path_entry to match your setup. See README.md
+iso_paths= [
+     "[ovh-nfs-vsphere-services] isos/rhel-8.8-x86_64-dvd.iso"
+]
+iso_checksum="517abcc67ee3b7212f57e180f5d30be3e8269e7a99e127a3399b7935c7e00a09"


### PR DESCRIPTION
- Create base template for RHEL 8.8
Tested by uploading ISO to "[tmp-iscsi-ovh] isos/rhel-8.8-x86_64-dvd.iso" and creating `d2iq-base-RHEL-88` in `users/users-ksphere-platform` folder.


@fatz Can you please upload RHEL 8.8 to `[ovh-nfs-vsphere-services] isos/rhel-8.8-x86_64-dvd.iso` as I dont have access.