### PR TITLE
fix: remove rocky-9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,22 +53,18 @@ ubuntu-ovf-20: manifests/ovf/d2iq-base-Ubuntu-20.04$(NAME_POSTFIX).ovf
 ubuntu-ovf-22: manifests/ovf/d2iq-base-Ubuntu-22.04$(NAME_POSTFIX).ovf
 ubuntu-ovf: ubuntu-ovf-20 ubuntu-ovf-22
 
-rocky: manifests/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX).json manifests/d2iq-base-RockyLinux-9.1$(NAME_POSTFIX).json manifests/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).json
+rocky: manifests/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX).json manifests/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).json
 rocky-test-87: manifests/tests/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX).json.clean
 rocky-test-87-clean: rocky-test-87 manifests/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX).json.clean
-rocky-test-91: manifests/tests/d2iq-base-RockyLinux-9.1$(NAME_POSTFIX).json.clean
-rocky-test-91-clean: rocky-test-91 manifests/d2iq-base-RockyLinux-9.1$(NAME_POSTFIX).json.clean
 rocky-test-95: manifests/tests/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).json.clean
-rocky-test-95-clean: rocky-test-91 manifests/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).json.clean
-rocky-test: rocky-test-87-clean rocky-test-91-clean rocky-test-95-clean
+rocky-test-95-clean: manifests/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).json.clean
+rocky-test: rocky-test-87-clean rocky-test-95-clean
 rocky-release-87: rocky-test-87 release/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX)
-rocky-release-91: rocky-test-91 release/d2iq-base-RockyLinux-9.1$(NAME_POSTFIX)
 rocky-release-95: rocky-test-95 release/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX)
-rocky-release: rocky-release-87 rocky-release-91 rocky-release-95
+rocky-release: rocky-release-87 rocky-release-95
 rocky-ovf-87: manifests/ovf/d2iq-base-RockyLinux-8.7$(NAME_POSTFIX).ovf
-rocky-ovf-91: manifests/ovf/d2iq-base-RockyLinux-9.1$(NAME_POSTFIX).ovf
 rocky-ovf-95: manifests/ovf/d2iq-base-RockyLinux-9.5$(NAME_POSTFIX).ovf
-rocky-ovf: rocky-ovf-87 rocky-ovf-91 rocky-ovf-95
+rocky-ovf: rocky-ovf-87 rocky-ovf-95
 
 centos: manifests/d2iq-base-CentOS-7.9$(NAME_POSTFIX).json
 centos-test-79: manifests/tests/d2iq-base-CentOS-7.9$(NAME_POSTFIX).json.clean

--- a/images/base-RockyLinux-9.1.pkrvar.hcl
+++ b/images/base-RockyLinux-9.1.pkrvar.hcl
@@ -1,4 +1,0 @@
-distribution="RockyLinux"
-distribution_version="9.1"
-iso_url="https://dl.rockylinux.org/vault/rocky/9.1/isos/x86_64/Rocky-9.1-20221215.1-x86_64-minimal.iso"
-iso_checksum="750c373c3206ae79784e436cc94fffc122296cf1bf8129a427dcd6ba7fac5888"

--- a/vsphere.pkr.hcl
+++ b/vsphere.pkr.hcl
@@ -208,7 +208,6 @@ locals {
     "RHEL"            = "${path.root}/bootfiles/rhel/rhel8.ks"
     "RockyLinux"      = "${path.root}/bootfiles/rocky/rocky.ks"
     "RockyLinux-8.7"  = "${path.root}/bootfiles/rocky/rocky-vault.ks"
-    "RockyLinux-9.1"  = "${path.root}/bootfiles/rocky/rocky-vault.ks"
     "RockyLinux-9.5"  = "${path.root}/bootfiles/rocky/rocky-vault.ks"
     "CentOS"          = "${path.root}/bootfiles/centos/centos7.ks"
     "OracleLinux"     = "${path.root}/bootfiles/oraclelinux/oraclelinux9.ks"


### PR DESCRIPTION
VMs created with Rocky-9.1 are no longer able to SSH from packer. 
We are removing support for rocky-9.1 since it is long deprecated.